### PR TITLE
Add 'boa.ssh' for syntax highlighting with a2ps

### DIFF
--- a/boa.ssh
+++ b/boa.ssh
@@ -1,0 +1,96 @@
+# Style sheet for Boa
+# As `java.ssh`:
+# Copyright (c) 1988-1993 Miguel Santana
+# Copyright (c) 1995-1999 Akim Demaille, Miguel Santana
+# As `boa.ssh`:
+# Copyright (c) 2022 Samuel W. Flint
+
+#
+# This file is not a part of a2ps (but is based on java.ssh from a2ps)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+
+style Boa is
+version is 1.0
+requires a2ps version 4.12a
+written by "Samuel W. Flint <swflint@flintfam.org>"
+
+first alphabet is
+   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_#$%"
+second alphabet is
+   "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._#$%"
+case sensitive
+
+documentation is
+  "Documentation comments are mapped to strong comments, and any other"
+  "comment is plain comment."
+end documentation
+
+keywords in Keyword are
+
+   fingerprint, RepositoryKind, FileKind, ChangeKind,
+   StatementKind, ExpressionKind, Visibility, ModifierKind,
+   CommentKind, input, Project, CodeRepository, Person,
+   Revision, ChangedFile, ASTRoot, Namespace, Declaration,
+   Type, Method, Variable, Statement, Expression, Modifier
+
+end keywords
+
+keywords in Keyword_strong are
+
+   abstract, break, byvalue, "case", cast, catch, const, continue,
+   default, do, else, extends, final, finally, for, future, generic,
+   goto, if, implements, import, inner, instanceof, native, new,
+   operator, outer, package, private, protected, public, rest, return,
+   static, super, switch, synchronized, throw, throws, transient, try,
+   var, volatile, while, visitor, foreach, exists, ifall, of, stack,
+   map, output, array, weight, sum, collection, top, bottom, set,
+   minimum, maximum, mean bool, byte, int, float, string, time, visit,
+   type, enum, before, after, stop
+   
+end keywords
+
+optional operators are
+   -> \rightarrow,
+   && \wedge,
+   || \vee,
+   != \neq,
+   == \equiv,
+   <<=,
+   >>=,
+   <= \leq,
+   >= \geq,
+   ! \not
+end operators
+
+# Class/Interface declarations
+operators are
+  (/(class|interface)/    # 1. Keyword
+   /([[:space:]]+)/	  # 2. Spaces
+   /([^[:space:]]+)/	  # 3. Class name
+   \1 Keyword_strong, \2 Plain, \3 Label_strong)
+end operators
+
+sequences are
+    "/*" Comment Comment "*/" Comment,
+    "/**" Comment_strong Comment_strong "*/" Comment_strong,
+    "//" Comment,
+    "#" Comment,
+    "{@" Label Label "@}" Label,
+    C-string
+end sequences
+end style

--- a/boa.ssh
+++ b/boa.ssh
@@ -36,8 +36,13 @@ second alphabet is
 case sensitive
 
 documentation is
-  "Documentation comments are mapped to strong comments, and any other"
-  "comment is plain comment."
+
+  "This provides support for the Boa language (https://boa.cs.iastate.edu/)."
+  "It may be found at https://github.com/boalang/syntax-highlight/"
+  ""
+  "Basic Boa keywords are supported, but no builtin functions.  In the"
+  "second level, some operators are specially fontified.  There is no"
+  "special fontification for function or variable declarations."
 end documentation
 
 keywords in Keyword are
@@ -77,18 +82,7 @@ optional operators are
    ! \not
 end operators
 
-# Class/Interface declarations
-operators are
-  (/(class|interface)/    # 1. Keyword
-   /([[:space:]]+)/	  # 2. Spaces
-   /([^[:space:]]+)/	  # 3. Class name
-   \1 Keyword_strong, \2 Plain, \3 Label_strong)
-end operators
-
 sequences are
-    "/*" Comment Comment "*/" Comment,
-    "/**" Comment_strong Comment_strong "*/" Comment_strong,
-    "//" Comment,
     "#" Comment,
     "{@" Label Label "@}" Label,
     C-string


### PR DESCRIPTION
This provides support for syntax highlighting using the a2ps tool.